### PR TITLE
fix: remove redefinition of Serial

### DIFF
--- a/firmware/sd2-card-config.h
+++ b/firmware/sd2-card-config.h
@@ -18,7 +18,7 @@
 /* Select output device for print() function */
 #	define SERIAL_DEVICE	0				/* 0:SerialUSB  1=: Serial UART device */
 #	if SERIAL_DEVICE == 0  	
-#		define Serial Serial				/* Use USB CDC port */
+// #		define Serial Serial				/* Use USB CDC port */
 #		define BPS_9600		/* Nothing */ 
 #		define BPS_115200 	/* Nothing */ 
 #	else


### PR DESCRIPTION
When using the library in the online IDE:

```
sd-card-library-photon-compat/sd2-card-config.h:21:0: warning: "Serial" redefined [enabled by default]
 #  define Serial Serial    /* Use USB CDC port */
 ^
In file included from ./inc/application.h:45:0,
                 from xxx.cpp:2:
../wiring/inc/spark_wiring_usbserial.h:94:0: note: this is the location of the previous definition
 #define Serial _fetch_global_serial()
 ^
In file included from sd-card-library-photon-compat/sd2-card.h:26:0,
                 from sd-card-library-photon-compat/sd-fat-util.h:27,
                 from sd-card-library-photon-compat/sd-fat.h:27,
                 from sd-card-library-photon-compat/sd-card-library-photon-compat.h:18,
                 from wala.cpp:2:
xxx.cpp: In function 'void setup()':
This looks like an error in sd-card-library-photon-compat library. Would you like to create an issue on GitHub to let the author know?
CREATE ISSUE
sd-card-library-photon-compat/sd2-card-config.h:21:18: error: 'Serial' was not declared in this scope
 #  define Serial Serial    /* Use USB CDC port */
```
